### PR TITLE
Remove space in package name

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,7 +7,7 @@
 # Robby Colvin <geetarista@gmail.com>
 #
 class daisy_disk {
-  package { 'Daisy Disk':
+  package { 'DaisyDisk':
     provider => 'compressed_app',
     source   => 'http://www.daisydiskapp.com/downloads/DaisyDisk.zip',
   }

--- a/spec/classes/daisy_disk_spec.rb
+++ b/spec/classes/daisy_disk_spec.rb
@@ -14,7 +14,7 @@ CLASSES = {
 CLASSES.each do |klass, version|
   describe klass do
     it do
-      should contain_package('Daisy Disk').with({
+      should contain_package('DaisyDisk').with({
         :provider => version[:provider],
         :source   => version[:source]
       })


### PR DESCRIPTION
This newer versions of DaisyDisk don't have spaces in the filename.
